### PR TITLE
Fixed crash when nav'ing back

### DIFF
--- a/Sharpnado.Presentation.Forms.Droid/Renderers/HorizontalList/AndroidHorizontalListViewRenderer.cs
+++ b/Sharpnado.Presentation.Forms.Droid/Renderers/HorizontalList/AndroidHorizontalListViewRenderer.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 
 using Android.Content;
 using Android.Support.V7.Widget;
@@ -126,7 +127,8 @@ namespace Sharpnado.Presentation.Forms.Droid.Renderers.HorizontalList
 
         private void OnPreDraw(object sender, ViewTreeObserver.PreDrawEventArgs e)
         {
-            if (Control == null)
+            // Since Control.IsDisposed() can't be accessed we need to check that manually
+            if (Control == null || Control.Handle == IntPtr.Zero)
             {
                 return;
             }


### PR DESCRIPTION
This fixes the following crash in Android:

```
​​​​[MonoDroid] UNHANDLED EXCEPTION:
[MonoDroid] System.ObjectDisposedException: Cannot access a disposed object.
[MonoDroid] Object name: 'Sharpnado.Presentation.Forms.Droid.Renderers.HorizontalList.SlowRecyclerView'.
[MonoDroid]   at Java.Interop.JniPeerMembers.AssertSelf (Java.Interop.IJavaPeerable self) [0x00029] in <0ad2222fd7074badb5de547b1521aab0>:0 
[MonoDroid]   at Java.Interop.JniPeerMembers+JniInstanceMethods.InvokeNonvirtualInt32Method (System.String encodedMember, Java.Interop.IJavaPeerable self, Java.Interop.JniArgumentValue* parameters) [0x00000] in <0ad2222fd7074badb5de547b1521aab0>:0 
[MonoDroid]   at Android.Views.View.get_Height () [0x0000a] in <ad2f15102b3a4d36b40e9b0cbc11c376>:0 
[MonoDroid]   at Sharpnado.Presentation.Forms.Droid.Renderers.HorizontalList.AndroidHorizontalListViewRenderer.OnPreDraw (System.Object sender, Android.Views.ViewTreeObserver+PreDrawEventArgs e) [0x0000b] in D:\Dev\Sharpnado\src\Xamarin-Forms-Practices\Sharpnado.Presentation.Forms\Sharpnado.Presentation.Forms.Droid\Renderers\HorizontalList\AndroidHorizontalListViewRenderer.cs:135 
[MonoDroid]   at Android.Views.ViewTreeObserver+IOnPreDrawListenerImplementor.OnPreDraw () [0x00013] in <ad2f15102b3a4d36b40e9b0cbc11c376>:0 
[MonoDroid]   at Android.Views.ViewTreeObserver+IOnPreDrawListenerInvoker.n_OnPreDraw (System.IntPtr jnienv, System.IntPtr native__this) [0x00009] in <ad2f15102b3a4d36b40e9b0cbc11c376>:0 
[MonoDroid]   at (wrapper dynamic-method) System.Object.110(intptr,intptr)
[art] JNI RegisterNativeMethods: attempt to register 0 native methods for android.runtime.JavaProxyThrowable
[Mono] DllImport searching in: '__Internal' ('(null)').
[Mono] Searching for 'java_interop_jnienv_throw'.
[Mono] Probing 'java_interop_jnienv_throw'.
[Mono] Found as 'java_interop_jnienv_throw'.
[mono] 
[mono] Unhandled Exception:
[mono] System.ObjectDisposedException: Cannot access a disposed object.
[mono] Object name: 'Sharpnado.Presentation.Forms.Droid.Renderers.HorizontalList.SlowRecyclerView'.
[mono]   at (wrapper dynamic-method) System.Object.110(intptr,intptr)
[mono]   at (wrapper native-to-managed) System.Object.110(intptr,intptr)
[mono-rt] [ERROR] FATAL UNHANDLED EXCEPTION: System.ObjectDisposedException: Cannot access a disposed object.
[mono-rt] Object name: 'Sharpnado.Presentation.Forms.Droid.Renderers.HorizontalList.SlowRecyclerView'.
[mono-rt]   at (wrapper dynamic-method) System.Object.110(intptr,intptr)
[mono-rt]   at (wrapper native-to-managed) System.Object.110(intptr,intptr)
```