### PR TITLE
Fixes #37 DataTemplateSelector - wrong Data Template recycled

### DIFF
--- a/Sharpnado.Presentation.Forms.iOS/Helpers/IdentifierFormatter.cs
+++ b/Sharpnado.Presentation.Forms.iOS/Helpers/IdentifierFormatter.cs
@@ -1,0 +1,12 @@
+﻿using Sharpnado.Presentation.Forms.iOS.Renderers.HorizontalList;
+
+namespace Sharpnado.Presentation.Forms.iOS.Helpers
+{
+    public static class IdentifierFormatter
+    {
+        public static string FormatDataTemplateCellIdentifier(int index)
+        {
+            return string.Concat(nameof(iOSViewCell), index);
+        }
+    }
+}

--- a/Sharpnado.Presentation.Forms.iOS/Renderers/HorizontalList/iOSHorizontalListViewRenderer.cs
+++ b/Sharpnado.Presentation.Forms.iOS/Renderers/HorizontalList/iOSHorizontalListViewRenderer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
@@ -296,13 +297,39 @@ namespace Sharpnado.Presentation.Forms.iOS.Renderers.HorizontalList
             _itemsSource = Element.ItemsSource;
 
             Control.DataSource = new iOSViewSource(Element);
-            Control.RegisterClassForCell(typeof(iOSViewCell), nameof(iOSViewCell));
+
+            if (Element.ItemTemplate is DataTemplateSelector)
+            {
+                RegisterCellDataTemplates();
+            }
+            else
+            {
+                Control.RegisterClassForCell(typeof(iOSViewCell), nameof(iOSViewCell));
+            }
 
             oldDataSource?.Dispose();
 
             if (_itemsSource is INotifyCollectionChanged newNotifyCollection)
             {
                 newNotifyCollection.CollectionChanged += OnCollectionChanged;
+            }
+        }
+
+        private void RegisterCellDataTemplates()
+        {
+            HashSet<Type> templateTypes = new HashSet<Type>();
+            foreach (var item in _itemsSource)
+            {
+                Type itemType = item.GetType();
+                if (!templateTypes.Contains(itemType))
+                {
+                    templateTypes.Add(itemType);
+                }
+            }
+
+            foreach (var itemType in templateTypes)
+            {
+                Control.RegisterClassForCell(typeof(iOSViewCell), itemType.Name);
             }
         }
 

--- a/Sharpnado.Presentation.Forms.iOS/Sharpnado.Presentation.Forms.iOS.csproj
+++ b/Sharpnado.Presentation.Forms.iOS/Sharpnado.Presentation.Forms.iOS.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Renderers\HorizontalList\SnappingCollectionViewLayout.cs" />
     <Compile Include="Renderers\HorizontalList\UIViewCellHolderQueue.cs" />
     <Compile Include="Renderers\iOSMaterialFrameRenderer.cs" />
+    <Compile Include="Helpers\IdentifierFormatter.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="MSBuildTasks">


### PR DESCRIPTION
Fixes issue #37
After checking the approach used on the ListView of the Xamarin.Forms I noticed that it requires different types of view models. I've used the same approach here, checking the data source and registering a cell type for each type of view model, and using the view model type name as the identifier.

Therefore, to fix the issue on the SillyPeople sample app was still required:
To create a new model for Favorite Silly Dude:
```
public class FavoriteSillyDudeVmo : SillyDudeVmo
{
        public FavoriteSillyDudeVmo(SillyDude dude, ICommand onItemTappedCommand) : base(dude, onItemTappedCommand)
        {
            IsFavorite = true;
        }
}
```
And in the `LoadSillyPeopleAsync` of the `SillyPeopleVm` to create the specific type of view model based on the `IsFavorite` flag:
```
await _sillyDudeService.GetSillyPeople().Select(dude => dude.IsFavorite 
? new FavoriteSillyDudeVmo(dude, GoToSillyDudeCommand)  
: new SillyDudeVmo(dude, GoToSillyDudeCommand)));
```

I'm not sure if that's the best approach! I would like to hear some feedback about it.