### PR TITLE
 NullReferenceException on _dragHelper

### DIFF
--- a/Sharpnado.Presentation.Forms.Droid/Renderers/HorizontalList/AndroidHorizontalListViewRenderer.cs
+++ b/Sharpnado.Presentation.Forms.Droid/Renderers/HorizontalList/AndroidHorizontalListViewRenderer.cs
@@ -62,8 +62,11 @@ namespace Sharpnado.Presentation.Forms.Droid.Renderers.HorizontalList
                     treeViewObserver.PreDraw -= OnPreDraw;
                 }
 
-                _dragHelper.AttachToRecyclerView(null);
-                _dragHelper = null;
+                if (_dragHelper != null)
+                {
+                    _dragHelper.AttachToRecyclerView(null);
+                    _dragHelper = null;
+                }
             }
 
             if (e.NewElement != null)


### PR DESCRIPTION
Fixes the following issue:
1) On an Android device, define a `HorizontalListView` at the top of the screen with `EnableDragAndDrop="false"`. Include the ability to scroll down so the `HorizontalListView` no longer appears.
2) While running the app, navigate to that screen and scroll down so the `HorizontalListView` no longer appears.
3) Scroll back up so the `HorizontalListView` will reappear.
4) Observe `NullReferenceException` on `_dragHelper`.